### PR TITLE
Bug Fix - Grammer error that a comma was left out in an array

### DIFF
--- a/app/Servers/Frontend/RegisterServer.php
+++ b/app/Servers/Frontend/RegisterServer.php
@@ -30,7 +30,7 @@ class RegisterServer extends CommonServer
 
         // 用户名和邮箱重复判断
         $search_where = [
-            'filter' => ['username', 'email']
+            'filter' => ['username', 'email'],
             'search' => [
                 'username' => $username,
                 'email'    => ['or', $email],


### PR DESCRIPTION
注册功能报错，原因是app/Servers/Frontend/RegisterServer.php文件中的$search_where变量缺少一个逗号